### PR TITLE
fix covid cases exclusion logic for matching

### DIFF
--- a/analysis/match_running.py
+++ b/analysis/match_running.py
@@ -7,7 +7,7 @@ covid_df = pd.read_csv(
 )
 covid_df = covid_df.loc[covid_df["patient_index_date"].notnull()]
 covid_df = covid_df.loc[covid_df["patient_index_date"] <= "2020-11-01"]
-covid_df = covid_df.loc[covid_df["died_date_ons"] <= covid_df["patient_index_date"]]
+covid_df = covid_df.loc[~(covid_df["died_date_ons"] <= covid_df["patient_index_date"])]
 covid_df.to_csv("output/input_covid_with_exclusions.csv", index=False)
 
 


### PR DESCRIPTION
previously it was dropping everyone except those who died in hospital, rather than the inverse of that